### PR TITLE
docs(repository): Switch to new repository schema

### DIFF
--- a/.repository/index.yaml
+++ b/.repository/index.yaml
@@ -1,0 +1,15 @@
+slug: ml-learning-lab
+description: Machine Learning Lab
+project: udacity
+namespace:
+status: archived
+icon: icon.svg
+license:
+  type: MIT
+  content: Jonathan Beverly <jrbeverly>
+  year: 2021
+topics: |-
+  [
+    "jupyter-notebook",
+    "machine-learning"
+  ]


### PR DESCRIPTION
Adopt new repository schema, switching to YAML.

This removes the old JSON + repository schema, switching to using YAML and a project oriented schema. The new project field makes the root of a project clear.

Additionally the language field has been removed as it was a fairly dynamic field.